### PR TITLE
Add an option to self-host dropzone js and css

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,12 @@ INSTALLED_APPS = [
 ]
 ```
 
+By default, the javascript and css for dropzone.js are loaded from unpkg cdn. If you want to self host thoses, you need to put the `dropzone.min.js` and `dropzone.min.css` in your static directory and add the following in `settings.py`:
+
+```python
+DRAGNDROP_RELATED_USE_CDN = False
+```
+
 Import the mixin and apply it to your "parent" class's `ModelAdmin`:
 
 ```python

--- a/dragndrop_related/templates/admin/dragndrop_related/change_form.html
+++ b/dragndrop_related/templates/admin/dragndrop_related/change_form.html
@@ -1,9 +1,14 @@
 {% extends change_form_template_parent %}
 {% load admin_urls %}
+{% load static %}
 
 {% block extrahead %}
     {{ block.super}}
-    <script src="https://unpkg.com/dropzone@5/dist/min/dropzone.min.js"></script>
+    {% if dropzone_use_cdn %}
+        <script src="https://unpkg.com/dropzone@5/dist/min/dropzone.min.js"></script>
+    {% else %}
+        <script src="{% static 'dropzone.min.js' %}"></script>
+    {% endif %}
     <script>
         Dropzone.autoDiscover = false;
     </script>
@@ -11,7 +16,11 @@
 
 {% block extrastyle %}
     {{ block.super }}
-    <link rel="stylesheet" href="https://unpkg.com/dropzone@5/dist/min/dropzone.min.css" type="text/css" />
+    {% if dropzone_use_cdn %}
+        <link rel="stylesheet" href="https://unpkg.com/dropzone@5/dist/min/dropzone.min.css" type="text/css" />
+    {% else %}
+        <link rel="stylesheet" href="{% static 'dropzone.min.css' %}" type="text/css" />
+    {% endif %}
     <style>
         .drag-and-drop-related input[type=submit] { padding: 2px 3px; }
         #dropzone-success { display: none; }

--- a/dragndrop_related/views.py
+++ b/dragndrop_related/views.py
@@ -7,7 +7,7 @@ from django.http import (HttpResponse, HttpResponseBadRequest,
 from django.urls import re_path, reverse
 from django.views.generic import DetailView
 from django.views.generic.edit import FormMixin, ProcessFormView
-
+from django.conf import settings
 
 class DragAndDropView(PermissionRequiredMixin, FormMixin, ProcessFormView,
                       DetailView):
@@ -149,6 +149,14 @@ class DragAndDropRelatedImageMixin(object):
         field on the related model
     '''
     dropzone_accepted_files = None
+
+
+    ''' Get the dropzone js and css location depending on the settings. If it
+        is defined in django's project settings, use this value. Otherwise, 
+        get from unpkg.com
+    '''
+    
+    dropzone_use_cdn = settings.DRAGNDROP_RELATED_USE_CDN if settings.DRAGNDROP_RELATED_USE_CDN else True
 
     def get_related_model_info(self):
         ''' Access the related model according to the value of

--- a/dragndrop_related/views.py
+++ b/dragndrop_related/views.py
@@ -150,13 +150,11 @@ class DragAndDropRelatedImageMixin(object):
     '''
     dropzone_accepted_files = None
 
-
     ''' Get the dropzone js and css location depending on the settings. If it
-        is defined in django's project settings, use this value. Otherwise, 
-        get from unpkg.com
+        is defined in django's project settings, load from STATIC folder.
+        Otherwise, load from unpkg.com
     '''
-    
-    dropzone_use_cdn = settings.DRAGNDROP_RELATED_USE_CDN if settings.DRAGNDROP_RELATED_USE_CDN else True
+    dropzone_use_cdn = settings.DRAGNDROP_RELATED_USE_CDN if hasattr(settings, "DRAGNDROP_RELATED_USE_CDN") else True
 
     def get_related_model_info(self):
         ''' Access the related model according to the value of
@@ -192,6 +190,8 @@ class DragAndDropRelatedImageMixin(object):
                 self.change_form_template_parent,
             'dropzone_accepted_files':
                 dropzone_accepted_files,
+            'dropzone_use_cdn':
+                self.dropzone_use_cdn,
         }
 
     def add_view(self, request, form_url='', extra_context=None):


### PR DESCRIPTION
I added an optional settings in `settings.py` to self-host the dropzone js and css. This covers the case where the app is used with a browser with no internet access or if you need to keep complete control over the loaded scripts.